### PR TITLE
Remove container horizontal margins on smaller screens

### DIFF
--- a/public/stylesheets/index.css
+++ b/public/stylesheets/index.css
@@ -532,11 +532,11 @@ header .issue-info {
 @media only screen and (min-width : 320px) and (max-width : 599px) {
   body {
     margin: 0;
-    padding: 5px 0;
+    padding: 0;
   }
 
   .container {
-    max-width: 300px;
+    width: 100%;
   }
 
   header .intro,
@@ -596,7 +596,7 @@ header .issue-info {
 
   .column {
     display: inline-block;
-    width: 268px;
+    width: 100%;
   }
 
   .other-archives {


### PR DESCRIPTION
Remove container horizontal margins on smaller screens on scalatimes.com. This looks better and gives a bit more breathing space for reading.

| Before | After |
| - | - |
| ![Screenshot 2020-08-28 at 14 33 11](https://user-images.githubusercontent.com/132215/91561192-75633680-e93b-11ea-969d-58455e2eed31.png) | ![Screenshot 2020-08-28 at 14 33 03](https://user-images.githubusercontent.com/132215/91561184-73997300-e93b-11ea-9bef-be101f32868a.png) |


