### PR TITLE
Fixes undefined title for none-Scala Times Issues

### DIFF
--- a/routes/archive.js
+++ b/routes/archive.js
@@ -107,7 +107,7 @@ function getCampaignsContent(campaigns) {
         var campaignTitle = getCampaignTitle(htmlContent);
 
         // Filter campaigns that start with "Scala Times Issue"
-        if (campaignTitle.startsWith("Scala Times Issue")) {
+        if (campaignTitle !== undefined && campaignTitle.startsWith("Scala Times Issue")) {
           var excerpt = getCampaignExcerpts(htmlContent);
           var campaignBody = getCampaignBody(htmlContent);
           var issueInfo = getIssueInfo(htmlContent);


### PR DESCRIPTION
```
/app/routes/archive.js:110
        if (campaignTitle.startsWith("Scala Times Issue")) {
                          ^

TypeError: Cannot read property 'startsWith' of undefined
```